### PR TITLE
Win2.7.0 贴图，“氛围”和“边框"分类，贴图边框位置不对. #704

### DIFF
--- a/src/MovieMator/ResourceDockGenerator/stickerdockwidget.cpp
+++ b/src/MovieMator/ResourceDockGenerator/stickerdockwidget.cpp
@@ -222,7 +222,7 @@ QString StickerDockWidget::getImageClassType(QString srcStr)
 {
     QJsonObject imageClassPropertyInfo;
     QString stickerDir = Util::resourcesPath() + "/template/sticker";
-    TranslationHelper::readJsonFile(stickerDir + "imageclass_property_info.json", imageClassPropertyInfo);
+    TranslationHelper::readJsonFile(stickerDir + "/imageclass_property_info.json", imageClassPropertyInfo);
 
     QString result = "";
     if (imageClassPropertyInfo.isEmpty())


### PR DESCRIPTION
Win2.7.0 贴图，“氛围”和“边框"分类，贴图边框位置不对. #704