### PR TITLE
导出时将XML中profile的帧率改成和consumer的帧率，并重新计算XML中保存的帧数。

### DIFF
--- a/src/MovieMator/src/docks/encodedock.cpp
+++ b/src/MovieMator/src/docks/encodedock.cpp
@@ -720,7 +720,7 @@ static int convertTimeToFramesWithNewFps(QString strOldTime, FRAME_RATE framerat
     double dFpsOld = framerateOld.nFrameRateNum * 1.0 / framerateOld.nFrameRateDen;
     double dFpsNew = framerateNew.nFrameRateNum * 1.0 / framerateNew.nFrameRateDen;
 
-    int nFramesNew =  floor(nFrameOld * dFpsNew / dFpsOld);
+    int nFramesNew =  floor(nFrameOld * dFpsNew / dFpsOld + 0.5);
 
     return nFramesNew;
 }


### PR DESCRIPTION
遍历xml中所有in\out\length，根据consumer帧率重新计算。