### PR TITLE
Remove the transition settings button. Transitions properties are displayed when transitions are selected. clip is not selected after deletion. #770

### DIFF
--- a/src/MovieMator/src/docks/timelinedock.cpp
+++ b/src/MovieMator/src/docks/timelinedock.cpp
@@ -1020,12 +1020,6 @@ void TimelineDock::emitSelectedFromSelection()
             model()->setSelectedProducer(info->producer);
         }
 
-        // 如果选中的是转场，切换到转场的属性界面
-        if(info->producer->parent().get(kShotcutTransitionProperty))
-        {
-            onShowProperties(trackIndex, clipIndex);
-        }
-
         info->producer->set_in_and_out(0, -1);
 
         delete info;

--- a/src/MovieMator/src/docks/timelinedock.cpp
+++ b/src/MovieMator/src/docks/timelinedock.cpp
@@ -1020,6 +1020,12 @@ void TimelineDock::emitSelectedFromSelection()
             model()->setSelectedProducer(info->producer);
         }
 
+        // 如果选中的是转场，切换到转场的属性界面
+        if(info->producer->parent().get(kShotcutTransitionProperty))
+        {
+            onShowProperties(trackIndex, clipIndex);
+        }
+
         info->producer->set_in_and_out(0, -1);
 
         delete info;

--- a/src/MovieMator/src/mainwindow.cpp
+++ b/src/MovieMator/src/mainwindow.cpp
@@ -3136,6 +3136,8 @@ QWidget *MainWindow::loadProducerWidget(Mlt::Producer* producer)
         int clipIndex = m_timelineDock->selection().at(0);
         w = new LumaMixTransition(producer->parent(), trackIndex, clipIndex, this);
         scrollArea->setWidget(w);
+        // 转场就显示属性界面
+        showPropertiesDock();
         return w;
     } else if (playlist_type == producer->type()) {
         w = new TrackPropertiesWidget(*producer, this);

--- a/src/MovieMator/src/models/multitrackmodel.cpp
+++ b/src/MovieMator/src/models/multitrackmodel.cpp
@@ -1501,6 +1501,9 @@ void MultitrackModel::removeClip(int trackIndex, int clipIndex)
                 }
             }
             emit modified();
+
+            // 删除后不选中任何 clip
+            setSelection(trackIndex, -1);
         }
     }
 }
@@ -1539,6 +1542,9 @@ void MultitrackModel::liftClip(int trackIndex, int clipIndex)
             consolidateBlanks(playlist, trackIndex);
 
             emit modified();
+
+            // 删除后不选中任何 clip
+            setSelection(trackIndex, -1);
         }
     }
 }
@@ -2198,6 +2204,9 @@ void MultitrackModel::removeTransition(int trackIndex, int clipIndex)
         roles << DurationRole;
         emit dataChanged(modelIndex, modelIndex, roles);
         emit modified();
+
+        // 删除后不选中任何 clip
+        setSelection(trackIndex, -1);
     }
 }
 

--- a/src/MovieMator/src/qml/timeline/Clip.qml
+++ b/src/MovieMator/src/qml/timeline/Clip.qml
@@ -459,7 +459,7 @@ Rectangle {
             if(mainwindow)
                 mainwindow.setMultitrackAsCurrentProducer()
 
-            // 如果当前选中的是转场，就显示属性界面
+            // 如果当前界面是转场的滤镜界面，点击转场时切换到属性界面
             if(isTransition)
             {
                 console.assert(timeline);

--- a/src/MovieMator/src/qml/timeline/Clip.qml
+++ b/src/MovieMator/src/qml/timeline/Clip.qml
@@ -458,6 +458,14 @@ Rectangle {
             console.assert(mainwindow);
             if(mainwindow)
                 mainwindow.setMultitrackAsCurrentProducer()
+
+            // 如果当前选中的是转场，就显示属性界面
+            if(isTransition)
+            {
+                console.assert(timeline);
+                if(timeline)
+                    timeline.onShowProperties(trackIndex, index)
+            }
         }
     }
 
@@ -1322,18 +1330,6 @@ Rectangle {
             }
         }
 
-
-        //转场菜单
-        MenuItem {
-//            text: qsTr(!isTransition ? 'Properties' : 'Transition Settings')     // qsTr('Properties')
-            text: !isTransition ? qsTr('Properties') : qsTr('Transition Settings')
-            visible: isTransition
-            onTriggered: {
-                console.assert(timeline);
-                if(timeline)
-                    timeline.onShowProperties(trackIndex, index)
-            }
-        }
         // 移除菜单（只对转场有效）
         MenuItem {
             visible: isTransition

--- a/src/MovieMator/src/qml/timeline/TimelineToolbar.qml
+++ b/src/MovieMator/src/qml/timeline/TimelineToolbar.qml
@@ -362,33 +362,6 @@ ToolBar {
                 }
             }
 
-            // Add -转场设置按钮（原转场属性）
-            CustomToolbutton {
-                id: transitionButton
-                action: setTransitionAction
-                visible: true
-                bEnabled: hasClipOrTrackSelected && tracksRepeater.itemAt(currentTrack).clipAt(timeline.selection[0]).isTransition
-
-                implicitWidth: 44
-                implicitHeight: 44
-
-                customText:qsTr('Transition Settings')
-
-                customIconSource: 'qrc:///timeline/timeline-toolbar-transition-n.png'
-                pressedIconSource: 'qrc:///timeline/timeline-toolbar-transition-p.png'
-                disabledIconSource: 'qrc:///timeline/timeline-toolbar-transition-d.png'
-            }
-            // Add -End
-
-            Rectangle {
-                implicitWidth: 44
-                implicitHeight: 44
-                color: 'transparent'
-                Image {
-                    anchors.centerIn: parent
-                    source: 'qrc:///timeline/timeline-toolbar-separator.png'
-                }
-            }
             // Add -显示所有 Clips
             CustomToolbutton {
                 id: allClipsButton
@@ -772,21 +745,6 @@ ToolBar {
             console.assert(timeline);
             if(timeline){
                 filterMenu.popup(filterButton, timeline.dockPosition);
-            }
-        }
-    }
-    // Add -End
-
-    // Add -转场设置按钮
-    Action {
-        id: setTransitionAction
-        tooltip: qsTr("Set the transition property")
-        enabled: hasClipOrTrackSelected
-        onTriggered: {
-            console.assert(timeline);
-            // 只有点击转场才会弹出转场设置（属性）框，普通clip不弹属性框
-            if(timeline && tracksRepeater.itemAt(currentTrack).clipAt(timeline.selection[0]).isTransition){
-                timeline.onShowProperties(currentTrack, timeline.selection[0])
             }
         }
     }


### PR DESCRIPTION
Remove the transition settings button. Transitions properties are displayed when transitions are selected. clip is not selected after deletion. #770
